### PR TITLE
[Core] Implement Integer asserter (UI Validation)

### DIFF
--- a/src/UI/Resolver/Validator/RawValueValidator.php
+++ b/src/UI/Resolver/Validator/RawValueValidator.php
@@ -110,6 +110,28 @@ class RawValueValidator implements UIValidatorInterface
     }
 
     /**
+     * Exceptions are caught in order to be processed later
+     * @param mixed $value Integer ?
+     *
+     * @return mixed Untouched value
+     */
+    public function mustBeInteger($value, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null)
+    {
+        $this->validationEngine->validateFieldValue(
+            $parentValidator ?: $this,
+            function () use ($value, $propertyPath, $exceptionMessage) {
+                Assertion::integer(
+                    $value,
+                    $exceptionMessage,
+                    $propertyPath
+                );
+            }
+        );
+
+        return $value;
+    }
+
+    /**
      * @inheritdoc
      */
     public function createUIValidationException(string $message, string $propertyPath = null): UIValidationException

--- a/src/UI/Resolver/Validator/RequestAttributeValueValidator.php
+++ b/src/UI/Resolver/Validator/RequestAttributeValueValidator.php
@@ -123,6 +123,24 @@ class RequestAttributeValueValidator implements UIValidatorInterface
     }
 
     /**
+     * Exceptions are caught in order to be processed later
+     *
+     * @throws CommandMappingException If any mapping validation failed
+     * @return mixed Untouched value
+     */
+    public function mustBeInteger(ServerRequestInterface $request, string $attributeKey, string $exceptionMessage = null)
+    {
+        $value = $this->extractValueFromRequestAttribute($request, $attributeKey);
+
+        return $this->rawValueValidator->mustBeInteger(
+            $value,
+            $attributeKey,
+            $this,
+            $exceptionMessage
+        );
+    }
+
+    /**
      * @inheritdoc
      */
     public function createUIValidationException(string $message, string $propertyPath = null): UIValidationException

--- a/src/UI/Resolver/Validator/RequestQueryStringValueValidator.php
+++ b/src/UI/Resolver/Validator/RequestQueryStringValueValidator.php
@@ -123,6 +123,24 @@ class RequestQueryStringValueValidator implements UIValidatorInterface
     }
 
     /**
+     * Exceptions are caught in order to be processed later
+     *
+     * @throws CommandMappingException If any mapping validation failed
+     * @return mixed Untouched value
+     */
+    public function mustBeInteger(ServerRequestInterface $request, string $queryStringKey, string $exceptionMessage = null)
+    {
+        $value = $this->extractValueFromRequestQueryString($request, $queryStringKey);
+
+        return $this->rawValueValidator->mustBeInteger(
+            $value,
+            $queryStringKey,
+            $this,
+            $exceptionMessage
+        );
+    }
+
+    /**
      * @inheritdoc
      */
     public function createUIValidationException(string $message, string $propertyPath = null): UIValidationException

--- a/tests/units/UI/Resolver/Validator/RawValueValidator.php
+++ b/tests/units/UI/Resolver/Validator/RawValueValidator.php
@@ -138,6 +138,20 @@ class RawValueValidator extends atoum
         );
     }
 
+    /**
+     * @dataProvider notIntegerDataProvider
+     */
+    public function test_it_gets_value_even_if_not_integer_value_detected($propertyPath, $errorMessage, $value, array $expectedNormalizedException)
+    {
+        $this->testInvalidValue(
+            $errorMessage,
+            $propertyPath,
+            $value,
+            $expectedNormalizedException,
+            'mustBeInteger'
+        );
+    }
+
     protected function notArrayDataProvider(): array
     {
         $values = $this->createAllScalars();
@@ -150,6 +164,14 @@ class RawValueValidator extends atoum
     {
         $values = $this->createAllScalars();
         unset($values['float']);
+
+        return $values;
+    }
+
+    protected function notIntegerDataProvider(): array
+    {
+        $values = $this->createAllScalars();
+        unset($values['int']);
 
         return $values;
     }

--- a/tests/units/UI/Resolver/Validator/RequestAttributeValueValidator.php
+++ b/tests/units/UI/Resolver/Validator/RequestAttributeValueValidator.php
@@ -142,6 +142,15 @@ class RequestAttributeValueValidator extends atoum
     }
 
     /**
+     * @dataProvider notIntegerDataProvider
+     */
+    public function test_it_gets_value_from_psr7_request_even_if_not_integer($propertyPath, $errorMessage, $value, array $expected)
+    {
+        // Given
+        $this->testInvalidValue($value, $value);
+    }
+
+    /**
      * @dataProvider notArrayDataProvider
      */
     public function test_it_gets_value_from_psr7_request_even_if_not_array($propertyPath, $errorMessage, $value, array $expected)
@@ -178,6 +187,14 @@ class RequestAttributeValueValidator extends atoum
     {
         $values = RawValueValidator::createAllScalars();
         unset($values['float']);
+
+        return $values;
+    }
+
+    protected function notIntegerDataProvider(): array
+    {
+        $values = RawValueValidator::createAllScalars();
+        unset($values['int']);
 
         return $values;
     }

--- a/tests/units/UI/Resolver/Validator/RequestQueryStringValueValidator.php
+++ b/tests/units/UI/Resolver/Validator/RequestQueryStringValueValidator.php
@@ -150,6 +150,15 @@ class RequestQueryStringValueValidator extends atoum
         $this->testInvalidValue($value);
     }
 
+    /**
+     * @dataProvider notIntegerDataProvider
+     */
+    public function test_it_gets_value_from_psr7_request_even_if_not_integer($propertyPath, $errorMessage, $value, array $expected)
+    {
+        // Given
+        $this->testInvalidValue($value);
+    }
+
     protected function notBooleanDataProvider(): array
     {
         $values = RawValueValidator::createAllScalars();
@@ -178,6 +187,14 @@ class RequestQueryStringValueValidator extends atoum
     {
         $values = RawValueValidator::createAllScalars();
         unset($values['float']);
+
+        return $values;
+    }
+
+    protected function notIntegerDataProvider(): array
+    {
+        $values = RawValueValidator::createAllScalars();
+        unset($values['int']);
 
         return $values;
     }


### PR DESCRIPTION
#### Pain Point

We have our Engine. We now need some asserters.

#### TODO

- [x] Merge #18 first
- [x] Implement **RawValueValidator::mustBeInteger()**
  - Like `RawValueValidator::mustBeBoolean()` in #18
  - Add Atoum Unit Test
- [x] Implement **RequestAttributeValueValidator::mustBeInteger()**
  - Like `RequestAttributeValueValidator::mustBeBoolean()` in #18
  - Add Atoum Unit Test
- [x] Implement **RequestQueryStringValueValidator::mustBeInteger()**
  - Like `RequestQueryStringValueValidator::mustBeBoolean()` in #18
  - Add Atoum Unit Test