### PR TITLE
[Bug] Validation of Int and Float

### DIFF
--- a/src/UI/Resolver/Validator/RawValueValidator.php
+++ b/src/UI/Resolver/Validator/RawValueValidator.php
@@ -48,9 +48,9 @@ class RawValueValidator implements UIValidatorInterface
      * Exceptions are caught in order to be processed later
      * @param mixed $value Boolean ?
      *
-     * @return mixed Untouched value
+     * @return boolean Value casted into boolean or false
      */
-    public function mustBeBoolean($value, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null)
+    public function mustBeBoolean($value, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null): bool
     {
         $this->validationEngine->validateFieldValue(
             $parentValidator ?: $this,
@@ -64,7 +64,12 @@ class RawValueValidator implements UIValidatorInterface
             }
         );
 
-        return $value;
+        // Otherwise "false" would return true
+        if (in_array($value, [true, 'true', '1', 1], true)) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -93,9 +98,9 @@ class RawValueValidator implements UIValidatorInterface
      * Exceptions are caught in order to be processed later
      * @param mixed $value Float ?
      *
-     * @return mixed Untouched value
+     * @return float Value casted into float or -1
      */
-    public function mustBeFloat($value, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null)
+    public function mustBeFloat($value, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null): float
     {
         if (is_numeric($value)) {
             $value = (float) $value;
@@ -112,6 +117,10 @@ class RawValueValidator implements UIValidatorInterface
             }
         );
 
+        if (!is_float($value)) {
+            return -1;
+        }
+
         return $value;
     }
 
@@ -119,9 +128,9 @@ class RawValueValidator implements UIValidatorInterface
      * Exceptions are caught in order to be processed later
      * @param mixed $value Integer ?
      *
-     * @return mixed Untouched value
+     * @return int Value casted into int or -1
      */
-    public function mustBeInteger($value, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null)
+    public function mustBeInteger($value, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null): int
     {
         if (is_numeric($value)) {
             $value = (int) $value;
@@ -137,6 +146,10 @@ class RawValueValidator implements UIValidatorInterface
                 );
             }
         );
+
+        if (!is_int($value)) {
+            return -1;
+        }
 
         return $value;
     }

--- a/src/UI/Resolver/Validator/RawValueValidator.php
+++ b/src/UI/Resolver/Validator/RawValueValidator.php
@@ -97,6 +97,10 @@ class RawValueValidator implements UIValidatorInterface
      */
     public function mustBeFloat($value, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null)
     {
+        if (is_numeric($value)) {
+            $value = (float) $value;
+        }
+
         $this->validationEngine->validateFieldValue(
             $parentValidator ?: $this,
             function() use ($value, $propertyPath, $exceptionMessage) {
@@ -119,6 +123,10 @@ class RawValueValidator implements UIValidatorInterface
      */
     public function mustBeInteger($value, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null)
     {
+        if (is_numeric($value)) {
+            $value = (int) $value;
+        }
+
         $this->validationEngine->validateFieldValue(
             $parentValidator ?: $this,
             function() use ($value, $propertyPath, $exceptionMessage) {

--- a/tests/units/UI/Resolver/Validator/RawValueValidator.php
+++ b/tests/units/UI/Resolver/Validator/RawValueValidator.php
@@ -89,25 +89,105 @@ class RawValueValidator extends atoum
     }
 
     /**
-     * @dataProvider notBooleanDataProvider
+     * @dataProvider booleanDataProvider
      */
-    public function test_it_gets_value_even_if_not_boolean_value_detected($propertyPath, $errorMessage, $value, array $expectedNormalizedException)
+    public function test_it_gets_value_even_if_boolean_valid($value, $expected)
     {
-        $this->testInvalidValue(
-            $errorMessage,
-            $propertyPath,
+        // Given
+        $uiValidationEngine = UIValidationEngine::initialize();
+        $sut = new SUT($uiValidationEngine);
+
+        // When
+        $actual = $sut->mustBeBoolean(
             $value,
-            $expectedNormalizedException,
-            'mustBeBoolean'
+            'accept',
+            null,
+            'Custom Exception message'
         );
+
+        // Then
+        $this
+            ->variable($actual)
+            ->isEqualTo($expected);
+
+        $uiValidationEngine->guardAgainstAnyUIValidationException();
     }
 
-    protected function notBooleanDataProvider(): array
+    protected function booleanDataProvider(): array
     {
-        $values = $this->createAllScalars();
-        unset($values['boolean']);
+        return [
+            [
+                'value' => true,
+                'expected' => true
+            ],
+            [
+                'value' => false,
+                'expected' => false
+            ],
+            [
+                'value' => 'true',
+                'expected' => true
+            ],
+            [
+                'value' => 'false',
+                'expected' => false
+            ],
+            [
+                'value' => 1,
+                'expected' => true
+            ],
+            [
+                'value' => 0,
+                'expected' => false
+            ],
+        ];
+    }
 
-        return $values;
+    public function test_it_gets_value_even_if_bad_boolean_detected()
+    {
+        // Given
+        $value = 'bad';
+        $propertyPath = 'latitude';
+        $errorMessage = 'Custom Exception message';
+
+        $expectedNormalizedExceptions = [
+            'errors' => [
+                [
+                'status' => 406,
+                'source' => ['parameter' => $propertyPath],
+                'title' => 'Invalid Parameter',
+                'detail' => $errorMessage,
+                ]
+            ]
+        ];
+
+        $uiValidationEngine = UIValidationEngine::initialize();
+        $sut = new SUT($uiValidationEngine);
+
+        // When
+        $actual = $sut->mustBeBoolean(
+            $value,
+            $propertyPath,
+            null,
+            $errorMessage
+        );
+
+        // Then
+        $this
+            ->variable($actual)
+            ->isEqualTo(false);
+
+        try {
+            $uiValidationEngine->guardAgainstAnyUIValidationException();
+        } catch (UIValidationCollectionException $e) {
+            $actual = $e->normalize();
+            $this->array($actual)
+                ->isEqualTo($expectedNormalizedExceptions);
+
+            return;
+        }
+
+        $this->throwError();
     }
 
     /**
@@ -125,53 +205,173 @@ class RawValueValidator extends atoum
     }
 
     /**
-     * @dataProvider notFloatDataProvider
+     * @dataProvider floatDataProvider
      */
-    public function test_it_gets_value_even_if_not_float_value_detected($propertyPath, $errorMessage, $value, array $expectedNormalizedException)
+    public function test_it_gets_value_even_if_float_valid($value, $expected)
     {
-        $this->testInvalidValue(
-            $errorMessage,
-            $propertyPath,
+        // Given
+        $uiValidationEngine = UIValidationEngine::initialize();
+        $sut = new SUT($uiValidationEngine);
+
+        // When
+        $actual = $sut->mustBeInteger(
             $value,
-            $expectedNormalizedException,
-            'mustBeFloat'
+            'age',
+            null,
+            'Custom Exception message'
         );
+
+        // Then
+        $this
+            ->variable($actual)
+            ->isEqualTo($expected);
+
+        $uiValidationEngine->guardAgainstAnyUIValidationException();
+    }
+
+    protected function floatDataProvider(): array
+    {
+        return [
+            ['value' => 42, 'expected' => 42.0],
+            ['value' => '42', 'expected' => 42.0],
+            ['value' => '42.0', 'expected' => 42.0],
+            ['value' => 42.0, 'expected' => 42.0],
+        ];
+    }
+
+    public function test_it_gets_value_even_if_bad_float_detected()
+    {
+        // Given
+        $value = 'bad';
+        $propertyPath = 'latitude';
+        $errorMessage = 'Custom Exception message';
+
+        $expectedNormalizedExceptions = [
+            'errors' => [
+                [
+                'status' => 406,
+                'source' => ['parameter' => $propertyPath],
+                'title' => 'Invalid Parameter',
+                'detail' => $errorMessage,
+                ]
+            ]
+        ];
+
+        $uiValidationEngine = UIValidationEngine::initialize();
+        $sut = new SUT($uiValidationEngine);
+
+        // When
+        $actual = $sut->mustBeFloat(
+            $value,
+            $propertyPath,
+            null,
+            $errorMessage
+        );
+
+        // Then
+        $this
+            ->variable($actual)
+            ->isEqualTo(-1);
+
+        try {
+            $uiValidationEngine->guardAgainstAnyUIValidationException();
+        } catch (UIValidationCollectionException $e) {
+            $actual = $e->normalize();
+            $this->array($actual)
+                ->isEqualTo($expectedNormalizedExceptions);
+
+            return;
+        }
+
+        $this->throwError();
     }
 
     /**
-     * @dataProvider notIntegerDataProvider
+     * @dataProvider integerDataProvider
      */
-    public function test_it_gets_value_even_if_not_integer_value_detected($propertyPath, $errorMessage, $value, array $expectedNormalizedException)
+    public function test_it_gets_value_even_if_integer_valid($value, $expected)
     {
-        $this->testInvalidValue(
-            $errorMessage,
-            $propertyPath,
+        // Given
+        $uiValidationEngine = UIValidationEngine::initialize();
+        $sut = new SUT($uiValidationEngine);
+
+        // When
+        $actual = $sut->mustBeInteger(
             $value,
-            $expectedNormalizedException,
-            'mustBeInteger'
+            'age',
+            null,
+            'Custom Exception message'
         );
+
+        // Then
+        $this
+            ->variable($actual)
+            ->isEqualTo($expected);
+
+        $uiValidationEngine->guardAgainstAnyUIValidationException();
+    }
+
+    protected function integerDataProvider(): array
+    {
+        return [
+            ['value' => 42, 'expected' => 42],
+            ['value' => '42', 'expected' => 42],
+            ['value' => '42.0', 'expected' => 42],
+            ['value' => 42.0, 'expected' => 42],
+        ];
+    }
+
+    public function test_it_gets_value_even_if_bad_integer_detected()
+    {
+        // Given
+        $value = 'bad';
+        $propertyPath = 'age';
+        $errorMessage = 'Custom Exception message';
+
+        $expectedNormalizedExceptions = [
+            'errors' => [
+                [
+                'status' => 406,
+                'source' => ['parameter' => $propertyPath],
+                'title' => 'Invalid Parameter',
+                'detail' => $errorMessage,
+                ]
+            ]
+        ];
+
+        $uiValidationEngine = UIValidationEngine::initialize();
+        $sut = new SUT($uiValidationEngine);
+
+        // When
+        $actual = $sut->mustBeInteger(
+            $value,
+            $propertyPath,
+            null,
+            $errorMessage
+        );
+
+        // Then
+        $this
+            ->variable($actual)
+            ->isEqualTo(-1);
+
+        try {
+            $uiValidationEngine->guardAgainstAnyUIValidationException();
+        } catch (UIValidationCollectionException $e) {
+            $actual = $e->normalize();
+            $this->array($actual)
+                ->isEqualTo($expectedNormalizedExceptions);
+
+            return;
+        }
+
+        $this->throwError();
     }
 
     protected function notArrayDataProvider(): array
     {
         $values = $this->createAllScalars();
         unset($values['array']);
-
-        return $values;
-    }
-
-    protected function notFloatDataProvider(): array
-    {
-        $values = $this->createAllScalars();
-        unset($values['float']);
-
-        return $values;
-    }
-
-    protected function notIntegerDataProvider(): array
-    {
-        $values = $this->createAllScalars();
-        unset($values['int']);
 
         return $values;
     }


### PR DESCRIPTION
### Pain Point
The Object that implement `ServerRequestInterface` and that is send to be resolve, seems to store all of his data as string, even integer and float.
The methods `mustBeInteger` and `mustBeFloat` should try to convert the value that is given to them.

### Exemple
A POST request with key `weight` and value `52.12`
The object **Request** is given to the resolver which contain in his method `validateThenMapAttributes` :

```php
$weight = $this->attributeValueValidator->mustBeFloat(
            $request,
            'weight',
            'Le poids ne doit comporter que des chiffres.'
);
```

Always throw an Exception.

### Correction
For the method mustBeFloat a cast should be added :
```php
if (is_numeric($value)) {
      $value = (float) $value;
}
```

And for mustBeInteger :
```php
if (is_numeric($value)) {
      $value = (int) $value;
}
```
