### PR TITLE
[DX] Lead Ammit to be dependency free - Scalar I

### DIFF
--- a/src/Domain/BooleanValidation.php
+++ b/src/Domain/BooleanValidation.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types = 1);
+
+namespace Imedia\Ammit\Domain;
+
+/**
+ * @author Guillaume MOREL <g.morel@imediafrance.fr>
+ */
+class BooleanValidation
+{
+    /**
+     * Valid against UUID format
+     * @param mixed $value String to validate
+     * @return bool
+     */
+    public function isBooleanValid($value): bool
+    {
+        if (in_array($value, [true, false, 1, 0, '1', '0', 'true', 'false'], true)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/UI/Resolver/Validator/Implementation/Pure/ArrayValidatorTrait.php
+++ b/src/UI/Resolver/Validator/Implementation/Pure/ArrayValidatorTrait.php
@@ -2,7 +2,7 @@
 
 namespace Imedia\Ammit\UI\Resolver\Validator\Implementation\Pure;
 
-use Assert\Assertion;
+use Assert\InvalidArgumentException;
 use Imedia\Ammit\UI\Resolver\UIValidationEngine;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
 
@@ -25,10 +25,22 @@ trait ArrayValidatorTrait
         $this->validationEngine->validateFieldValue(
             $parentValidator ?: $this,
             function() use ($value, $propertyPath, $exceptionMessage) {
-                Assertion::isArray(
-                    $value,
+                if (is_array($value)) {
+                    return;
+                }
+
+                if (null === $exceptionMessage) {
+                    $exceptionMessage = sprintf(
+                        'Value "%s" is not an array.',
+                        $value
+                    );
+                }
+
+                throw new InvalidArgumentException(
                     $exceptionMessage,
-                    $propertyPath
+                    0,
+                    $propertyPath,
+                    $value
                 );
             }
         );

--- a/src/UI/Resolver/Validator/Implementation/Pure/BooleanValidatorTrait.php
+++ b/src/UI/Resolver/Validator/Implementation/Pure/BooleanValidatorTrait.php
@@ -2,7 +2,8 @@
 
 namespace Imedia\Ammit\UI\Resolver\Validator\Implementation\Pure;
 
-use Assert\Assertion;
+use Assert\InvalidArgumentException;
+use Imedia\Ammit\Domain\BooleanValidation;
 use Imedia\Ammit\UI\Resolver\UIValidationEngine;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
 
@@ -25,11 +26,23 @@ trait BooleanValidatorTrait
         $this->validationEngine->validateFieldValue(
             $parentValidator ?: $this,
             function() use ($value, $propertyPath, $exceptionMessage) {
-                Assertion::inArray(
-                    $value,
-                    [true, false, 1, 0, '1', '0', 'true', 'false'],
+                $booleanValidation = new BooleanValidation();
+                if ($booleanValidation->isBooleanValid($value)) {
+                    return;
+                }
+
+                if (null === $exceptionMessage) {
+                    $exceptionMessage = sprintf(
+                        'Value "%s" is not a boolean.',
+                        $value
+                    );
+                }
+
+                throw new InvalidArgumentException(
                     $exceptionMessage,
-                    $propertyPath
+                    0,
+                    $propertyPath,
+                    $value
                 );
             }
         );

--- a/tests/units/UI/Resolver/Validator/Implementation/Pure/BooleanValidatorTrait.php
+++ b/tests/units/UI/Resolver/Validator/Implementation/Pure/BooleanValidatorTrait.php
@@ -73,7 +73,7 @@ class BooleanValidatorTrait extends atoum
     {
         // Given
         $value = 'bad';
-        $propertyPath = 'latitude';
+        $propertyPath = 'isOk';
         $errorMessage = 'Custom Exception message';
 
         $expectedNormalizedExceptions = [


### PR DESCRIPTION
Rebund of https://github.com/imediafrance/ammit/issues/38

#### TODO

- [x] Validate Array without `beberlei/assert`
  - Refactor [Pure\ArrayValidatorTrait](https://github.com/imediafrance/ammit/blob/master/src/UI/Resolver/Validator/Implementation/Pure/ArrayValidatorTrait.php)
  - Like [Imedia\Ammit\DomainUuidValidation](https://github.com/imediafrance/ammit/blob/master/src/Domain/MailMxValidation.php)
- [x] Validate Boolean without `beberlei/assert`
  - Refactor [Pure\BooleanValidatorTrait](https://github.com/imediafrance/ammit/blob/master/src/UI/Resolver/Validator/Implementation/Pure/BooleanValidatorTrait.php)
  - Like [Imedia\Ammit\DomainUuidValidation](https://github.com/imediafrance/ammit/blob/master/src/Domain/MailMxValidation.php)
- [x] Unit testing both