### PR TITLE
[DX] Lead Ammit to be dependency free

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Build Status](https://travis-ci.com/imediafrance/ammit.svg?token=JcSB2GZng3ssVpoUAxup&branch=master)](https://travis-ci.com/imediafrance/ammit)
 [![Code Quality](https://scrutinizer-ci.com/g/imediafrance/ammit/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/imediafrance/ammit)
 [![Code Coverage](https://scrutinizer-ci.com/g/imediafrance/ammit/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/imediafrance/ammit)
-[![Dependency Status](https://www.versioneye.com/user/projects/58a229448516c700164c1e01/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/58a229448516c700164c1e01)
+[![Dependency Status](https://img.shields.io/badge/dependencies-none-green.svg)](https://www.versioneye.com/user/projects/58a229448516c700164c1e01)
 
 A light, stable and framework agnostic Command resolver library
 
@@ -39,7 +39,7 @@ Consequently it shall be **immutable**.
 
 - It provides a helper to easily **extract** scalar data from a PSR-7 HTTP Request (or a CLI input) in order to instantiate an immutable Command.
 - It allows to implement clean Commands (no public field).
-- It is designed to be a simple **UI Validation** framework based on the stable and [dependency free](https://en.wikipedia.org/wiki/Dependency_hell) [beberlei/assert](https://github.com/beberlei/assert) assertion library.
+- It is designed to be a simple **UI Validation** framework dependency free.
 - It is designed to ease segregating UI validation Vs Domain validation concerns
 
 ------------------
@@ -268,7 +268,7 @@ $email = $attributeValueValidator->mustBeUuid(
 );
 ```
 
-A validation is missing. You can still inject your own based on [beberlei/assert](https://github.com/beberlei/assert) assertion library.
+A validation is missing. You can still inject your own.
 
 
 #### Want to contribute ?

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     },
     "require": {
         "php": ">=7.0",
-        "beberlei/assert": "^2.4",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/src/Domain/StringValidation.php
+++ b/src/Domain/StringValidation.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types = 1);
+
+namespace Imedia\Ammit\Domain;
+
+/**
+ * @author Guillaume MOREL <g.morel@imediafrance.fr>
+ */
+class StringValidation
+{
+    /**
+     * String between X chars and Y chars
+     * @param mixed $value String to validate
+     * @param int $minLength
+     * @param int $maxLength
+     * @param string $encoding
+     *
+     * @return bool
+     */
+    public function isStringBetweenValid($value, int $minLength, int $maxLength, $encoding = 'utf8'): bool
+    {
+        if (false ===is_string($value)) {
+            return false;
+        }
+
+        $length = mb_strlen($value, $encoding);
+        if ($length < $minLength) {
+            return false;
+        }
+
+        if ($length > $maxLength) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/UI/Resolver/UIValidationEngine.php
+++ b/src/UI/Resolver/UIValidationEngine.php
@@ -3,9 +3,9 @@ declare(strict_types = 1);
 
 namespace Imedia\Ammit\UI\Resolver;
 
-use Assert\AssertionFailedException;
 use Imedia\Ammit\UI\Resolver\Exception\UIValidationCollectionException;
 use Imedia\Ammit\UI\Resolver\Exception\UIValidationException;
+use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
 
 /**
@@ -54,7 +54,7 @@ class UIValidationEngine
     {
         try {
             $validationFunction->call($this);
-        } catch (AssertionFailedException $exception) {
+        } catch (InvalidArgumentException $exception) {
             $this->addUIValidationException(
                 $UIValidator,
                 $exception->getMessage(),

--- a/src/UI/Resolver/Validator/Implementation/Pragmatic/StringBetweenLengthValidatorTrait.php
+++ b/src/UI/Resolver/Validator/Implementation/Pragmatic/StringBetweenLengthValidatorTrait.php
@@ -2,6 +2,7 @@
 
 namespace Imedia\Ammit\UI\Resolver\Validator\Implementation\Pragmatic;
 
+use Imedia\Ammit\Domain\StringValidation;
 use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
 use Imedia\Ammit\UI\Resolver\UIValidationEngine;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
@@ -9,31 +10,34 @@ use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
 /**
  * @author Guillaume MOREL <g.morel@imediafrance.fr>
  */
-trait InArrayValidatorTrait
+trait StringBetweenLengthValidatorTrait
 {
     /** @var UIValidationEngine */
     protected $validationEngine;
 
     /**
+     * Domain should be responsible for id format
      * Exceptions are caught in order to be processed later
-     * @param mixed $value Array ?
+     * @param mixed $value String ?
      *
-     * @return mixed
+     * @return mixed Untouched value
      */
-    public function mustBeInArray($value, array $availableValues, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null)
+    public function mustHaveLengthBetween($value, int $min, int $max, string $propertyPath = null, UIValidatorInterface $parentValidator = null, string $exceptionMessage = null)
     {
         $this->validationEngine->validateFieldValue(
             $parentValidator ?: $this,
-            function() use ($value, $availableValues, $propertyPath, $exceptionMessage) {
-                if (in_array($value, $availableValues, true)) {
+            function() use ($value, $min, $max, $propertyPath, $exceptionMessage) {
+                $stringValidation = new StringValidation();
+                if ($stringValidation->isStringBetweenValid($value, $min, $max)) {
                     return;
                 }
 
                 if (null === $exceptionMessage) {
                     $exceptionMessage = sprintf(
-                        'Value "%s" is not valid. Available values are "%s".',
+                        'Value "%s" must have between %d and %d chars.',
                         $value,
-                        implode('", "', $availableValues)
+                        $min,
+                        $max
                     );
                 }
 
@@ -46,6 +50,10 @@ trait InArrayValidatorTrait
             }
         );
 
-        return $value;
+        if (null === $value || !is_string($value)) {
+            return '';
+        }
+
+        return (string) $value;
     }
 }

--- a/src/UI/Resolver/Validator/Implementation/Pragmatic/UuidValidatorTrait.php
+++ b/src/UI/Resolver/Validator/Implementation/Pragmatic/UuidValidatorTrait.php
@@ -2,7 +2,7 @@
 
 namespace Imedia\Ammit\UI\Resolver\Validator\Implementation\Pragmatic;
 
-use Assert\InvalidArgumentException;
+use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
 use Imedia\Ammit\Domain\UuidValidation;
 use Imedia\Ammit\UI\Resolver\UIValidationEngine;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;

--- a/src/UI/Resolver/Validator/Implementation/Pure/ArrayValidatorTrait.php
+++ b/src/UI/Resolver/Validator/Implementation/Pure/ArrayValidatorTrait.php
@@ -2,7 +2,7 @@
 
 namespace Imedia\Ammit\UI\Resolver\Validator\Implementation\Pure;
 
-use Assert\InvalidArgumentException;
+use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
 use Imedia\Ammit\UI\Resolver\UIValidationEngine;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
 

--- a/src/UI/Resolver/Validator/Implementation/Pure/BooleanValidatorTrait.php
+++ b/src/UI/Resolver/Validator/Implementation/Pure/BooleanValidatorTrait.php
@@ -2,7 +2,7 @@
 
 namespace Imedia\Ammit\UI\Resolver\Validator\Implementation\Pure;
 
-use Assert\InvalidArgumentException;
+use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
 use Imedia\Ammit\Domain\BooleanValidation;
 use Imedia\Ammit\UI\Resolver\UIValidationEngine;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;

--- a/src/UI/Resolver/Validator/Implementation/Pure/DateValidatorTrait.php
+++ b/src/UI/Resolver/Validator/Implementation/Pure/DateValidatorTrait.php
@@ -2,7 +2,8 @@
 
 namespace Imedia\Ammit\UI\Resolver\Validator\Implementation\Pure;
 
-use Assert\InvalidArgumentException;
+use Imedia\Ammit\UI\Resolver\UIValidationEngine;
+use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
 use Imedia\Ammit\Domain\DateValidation;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
 
@@ -11,6 +12,9 @@ use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
  */
 trait DateValidatorTrait
 {
+    /** @var UIValidationEngine */
+    protected $validationEngine;
+
     /**
      * Exceptions are caught in order to be processed later
      * @param mixed $value Date Y-m-d ?

--- a/src/UI/Resolver/Validator/Implementation/Pure/FloatValidatorTrait.php
+++ b/src/UI/Resolver/Validator/Implementation/Pure/FloatValidatorTrait.php
@@ -2,7 +2,7 @@
 
 namespace Imedia\Ammit\UI\Resolver\Validator\Implementation\Pure;
 
-use Assert\InvalidArgumentException;
+use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
 use Imedia\Ammit\UI\Resolver\UIValidationEngine;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
 

--- a/src/UI/Resolver/Validator/Implementation/Pure/IntegerValidatorTrait.php
+++ b/src/UI/Resolver/Validator/Implementation/Pure/IntegerValidatorTrait.php
@@ -2,7 +2,7 @@
 
 namespace Imedia\Ammit\UI\Resolver\Validator\Implementation\Pure;
 
-use Assert\InvalidArgumentException;
+use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
 use Imedia\Ammit\UI\Resolver\UIValidationEngine;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
 

--- a/src/UI/Resolver/Validator/Implementation/Pure/StringValidatorTrait.php
+++ b/src/UI/Resolver/Validator/Implementation/Pure/StringValidatorTrait.php
@@ -2,7 +2,7 @@
 
 namespace Imedia\Ammit\UI\Resolver\Validator\Implementation\Pure;
 
-use Assert\InvalidArgumentException;
+use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
 use Imedia\Ammit\UI\Resolver\UIValidationEngine;
 use Imedia\Ammit\UI\Resolver\Validator\UIValidatorInterface;
 

--- a/src/UI/Resolver/Validator/InvalidArgumentException.php
+++ b/src/UI/Resolver/Validator/InvalidArgumentException.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types = 1);
+
+namespace Imedia\Ammit\UI\Resolver\Validator;
+
+/**
+ * @author Guillaume MOREL <g.morel@imediafrance.fr>
+ */
+class InvalidArgumentException extends \InvalidArgumentException
+{
+    /** @var string|null */
+    private $propertyPath;
+
+    /** @var mixed */
+    private $value;
+
+    public function __construct($message, int $code = 0, string $propertyPath = null, $value)
+    {
+        parent::__construct($message, $code);
+
+        $this->propertyPath = $propertyPath;
+        $this->value = $value;
+    }
+
+    /**
+     * User controlled way to define a sub-property causing
+     * the failure of a currently asserted objects.
+     *
+     * Useful to transport information about the nature of the error
+     * back to higher layers.
+     *
+     * @return string|null
+     */
+    public function getPropertyPath()
+    {
+        return $this->propertyPath;
+    }
+
+    /**
+     * Get the value that caused the assertion to fail.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/UI/Resolver/Validator/RequestAttributeValueValidator.php
+++ b/src/UI/Resolver/Validator/RequestAttributeValueValidator.php
@@ -3,10 +3,9 @@ declare(strict_types = 1);
 
 namespace Imedia\Ammit\UI\Resolver\Validator;
 
-use Assert\Assertion;
-use Assert\AssertionFailedException;
 use Imedia\Ammit\UI\Resolver\Exception\CommandMappingException;
 use Imedia\Ammit\UI\Resolver\Exception\UIValidationException;
+use Imedia\Ammit\UI\Resolver\ValueExtractor;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -33,16 +32,14 @@ class RequestAttributeValueValidator implements UIValidatorInterface
      */
     public function extractValueFromRequestAttribute(ServerRequestInterface $request, string $attributeKey)
     {
+        $valueExtractor = new ValueExtractor();
+
         try {
-            $attributes = $request->getParsedBody();
-
-            Assertion::isArray($attributes);
-            Assertion::keyExists($attributes, $attributeKey);
-
-            $value = $attributes[$attributeKey];
-
-            return $value;
-        } catch (AssertionFailedException $exception) {
+            return $valueExtractor->fromArray(
+                $request->getParsedBody(),
+                $attributeKey
+            );
+        } catch (InvalidArgumentException $exception) {
             throw CommandMappingException::fromAttribute(
                 $exception->getMessage(),
                 $exception->getPropertyPath()

--- a/src/UI/Resolver/Validator/RequestQueryStringValueValidator.php
+++ b/src/UI/Resolver/Validator/RequestQueryStringValueValidator.php
@@ -3,10 +3,9 @@ declare(strict_types = 1);
 
 namespace Imedia\Ammit\UI\Resolver\Validator;
 
-use Assert\Assertion;
-use Assert\AssertionFailedException;
 use Imedia\Ammit\UI\Resolver\Exception\CommandMappingException;
 use Imedia\Ammit\UI\Resolver\Exception\UIValidationException;
+use Imedia\Ammit\UI\Resolver\ValueExtractor;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -33,16 +32,14 @@ class RequestQueryStringValueValidator implements UIValidatorInterface
      */
     public function extractValueFromRequestQueryString(ServerRequestInterface $request, string $queryStringKey)
     {
+        $valueExtractor = new ValueExtractor();
+
         try {
-            $queryParams = $request->getQueryParams();
-
-            Assertion::isArray($queryParams);
-            Assertion::keyExists($queryParams, $queryStringKey);
-
-            $value = $queryParams[$queryStringKey];
-
-            return $value;
-        } catch (AssertionFailedException $exception) {
+            return $valueExtractor->fromArray(
+                $request->getQueryParams(),
+                $queryStringKey
+            );
+        } catch (InvalidArgumentException $exception) {
             throw CommandMappingException::fromParameter(
                 $exception->getMessage(),
                 $exception->getPropertyPath()

--- a/src/UI/Resolver/ValueExtractor.php
+++ b/src/UI/Resolver/ValueExtractor.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+
+namespace Imedia\Ammit\UI\Resolver;
+use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
+
+
+/**
+ * @author Guillaume MOREL <g.morel@imediafrance.fr>
+ */
+class ValueExtractor
+{
+    /**
+     * @param mixed $params
+     * @param string $key
+     *
+     * @return mixed
+     * @throws InvalidArgumentException If unable to extract
+     */
+    public function fromArray($params, string $key)
+    {
+        if (false === is_array($params)) {
+            throw new InvalidArgumentException(
+                sprintf('Value "%s" is not an array.', $params),
+                0,
+                null,
+                $params
+            );
+        }
+
+        if (false === array_key_exists($key, $params)) {
+            throw new InvalidArgumentException(
+                sprintf('Array does not contain an element with key "%s"', $key),
+                0,
+                null,
+                $params
+            );
+        }
+
+        return $params[$key];
+    }
+}

--- a/tests/units/Stub/ClosureFactory.php
+++ b/tests/units/Stub/ClosureFactory.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\Units\Imedia\Ammit\Stub;
 
-use Assert\InvalidArgumentException;
+use Imedia\Ammit\UI\Resolver\Validator\InvalidArgumentException;
 
 /**
  * Creating \Closure directly in an Atoum test is a really bad idea


### PR DESCRIPTION
#### Pain Point 

We are currently using `beberlei/assert` as assertion engine.
But our assertions are quite simple.
We may not need it.

This would allow us to be completely dependency free. Except for PSR-7

#### TODO

- [x] Merge #50 first
- [x] Merge #51 first
- [x] Merge #52 first
- [x] Remove use of `Assert\InvalidArgumentException` and replace it by a Custom Exception
- [x] Remove `beberlei/assert`
- [ ] Make sure they are unit tested